### PR TITLE
Add BucketReplications API Capabilities

### DIFF
--- a/src/v2/capabilities.rs
+++ b/src/v2/capabilities.rs
@@ -27,6 +27,8 @@ pub enum Capability {
     ReadFileRetentions,
     WriteFileRetentions,
     BypassGovernance,
+    ReadBucketReplications,
+    WriteBucketReplications,
 }
 
 pub type Capabilities = EnumSet<Capability>;
@@ -51,4 +53,6 @@ pub fn all_per_bucket_capabilites() -> Capabilities {
         | Capability::ReadFileRetentions
         | Capability::WriteFileRetentions
         | Capability::BypassGovernance
+        | Capability::ReadBucketReplications
+        | Capability::WriteBucketReplications
 }


### PR DESCRIPTION
b2_authorize_account fails, due to missing capabilities. This PR adds these capabilities and allows authorization to succeed again, but does not implement any functions using it.